### PR TITLE
Fix insert statistics with ha 2023.2

### DIFF
--- a/custom_components/stromnetzgraz/sensor.py
+++ b/custom_components/stromnetzgraz/sensor.py
@@ -284,7 +284,6 @@ class SNGrazDataCoordinator(DataUpdateCoordinator):
                 has_sum=True,
                 name=f"{meter._short_name} Consumption",
                 source=DOMAIN,
-                state_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
                 statistic_id=statistic_id,
                 unit_of_measurement=ENERGY_KILO_WATT_HOUR,
             )


### PR DESCRIPTION
At least on HA 2023.2.x the initial statistic import always fails because of the "state_unit_of_measurement" field is not allowed in StatisticMetaData.

I haven't found any documentation  for this object to verify this change. 