### PR TITLE
Remove device class from meter consumption sensor

### DIFF
--- a/custom_components/stromnetzgraz/sensor.py
+++ b/custom_components/stromnetzgraz/sensor.py
@@ -52,7 +52,6 @@ SENSORS: tuple[SensorEntityDescription, ...] = (
         key="lastMeterConsumption",
         name="Meter Consumption",
         icon="mdi:lightning-bolt-circle",
-        device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=ENERGY_KILO_WATT_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
     ),


### PR DESCRIPTION
The device class "energy" isn't allowed for state_class "measurement" per documentation and produces a warning message.

