### PR TITLE
Adjust reading binning, to allocate readings to the previous time interval

### DIFF
--- a/custom_components/stromnetzgraz/sensor.py
+++ b/custom_components/stromnetzgraz/sensor.py
@@ -208,6 +208,10 @@ class SNGrazDataCoordinator(DataUpdateCoordinator):
             # HA statistics finest interval is hourly, so let's break it down by hour
             # Also, do some filtering afterwards, pandas otherwise creates "empty" rows
             df = pandas.DataFrame(_data)
+            # The binning to full hours will attribute readings at full hours e.g. 9:00 to the bin of 9:00-10:00
+            # However the consumption actually belongs to the 8:00-9:00 bin.
+            # Strictly speaking, the same applies for any binning and reading interval
+            df["readTime"] = df["readTime"] - timedelta(seconds=1)
             df_hour = (
                 df.groupby(pandas.Grouper(freq="H", key="readTime"))
                 .agg(


### PR DESCRIPTION
When creating the 1 hour bins for the power consumption, the reading from full hours e.g. 9:00 is put into the bin of 9:00 - 10:00.
However, the reading represents the consumption of 8:45 - 9:00, it should be actually part of the 8:00 - 9:00 bin.
(likewise if processing daily readings, I guess they are reported at midnight, and thus would fall into the following day)

As an easy solution, I moved back the timestamps by 1 second. This allows the binning code to be unchanged, still putting the consumption values of full hours into the correct bin.